### PR TITLE
Basic implementation of local path callback function in lua

### DIFF
--- a/lua/pastify.lua
+++ b/lua/pastify.lua
@@ -25,8 +25,19 @@ M.config = {
   },
 }
 
+local imagePathRule
+
 M.getConfig = function()
+  imagePathRule = M.config.opts.local_path
+  M.config.opts.local_path = nil
   return M.config
+end
+
+M.createImagePathName = function()
+  if type(imagePathRule) == 'function' then
+    return imagePathRule()
+  end
+  return imagePathRule
 end
 
 local function create_command()

--- a/python3/pastify/main.py
+++ b/python3/pastify/main.py
@@ -25,6 +25,11 @@ class Pastify(object):
         vim.command(
             f'lua vim.notify("{msg}", vim.log.levels.{level or "INFO"})')
 
+    def get_image_path_name(self):
+        return vim.exec_lua(
+            'return require("pastify").createImagePathName()'
+        )
+
     def paste_text(self) -> None:
         options = self.config['opts']
         img = ImageGrab.grabclipboard()
@@ -54,7 +59,7 @@ class Pastify(object):
                 file_name = file_name[1:]
 
             if path.exists(
-                    f"{self.path}{options['local_path']}{file_name}.png"):
+                    f"{self.path}{self.get_image_path_name()}{file_name}.png"):
                 self.logger("File already exists.", "WARN")
                 return
 
@@ -63,9 +68,9 @@ class Pastify(object):
         placeholder_text = ""
         if self.config['opts']['save'] == "local":
             if self.config['opts']['absolute_path']:
-                assets_path = f"{self.path}{options['local_path']}"
+                assets_path = f"{self.path}{self.get_image_path_name()}"
             else:
-                assets_path = f".{options['local_path']}"
+                assets_path = f".{self.get_image_path_name()}"
             placeholder_text = f"{assets_path}{file_name}.png"
             if not path.exists(assets_path):
                 makedirs(assets_path)


### PR DESCRIPTION
Before when using `clipboard-image.nvim` is used a callback to dynamically
change the file structure in my `assets` folder based on my file name to keep my
files a bit more organised. For example:

```lua
local_path = function()
  return "./assets/" .. vim.fn.expand("%:t:r") .. "/img"
end,
```

This PR contains basic implementation for using a lua callback to generate the
local path on the fly. I wanted to just submit a preliminary, bare bones
PR^[There's much more to be done and clean up] and hear your thoughts on whether
you would be open to adding this capability to the project.
