### PR TITLE
Fix local file

### DIFF
--- a/python3/pastify/main.py
+++ b/python3/pastify/main.py
@@ -94,6 +94,12 @@ class Pastify(object):
             assets_path = path.abspath(
                 path.join(local_path, self.get_image_path_name())
             )
+
+            abs_img_path = path.join(assets_path, f"{file_name}.png")
+
+            if not path.exists(assets_path):
+                makedirs(assets_path)
+
             if not self.config["opts"]["absolute_path"]:
                 self.logger("Assets path is: " + str(repr(assets_path)), "INFO")
                 self.logger("Local path is: " + str(repr(local_path)), "INFO")
@@ -103,9 +109,7 @@ class Pastify(object):
                 assets_path = path.relpath(assets_path, current_file_path)
                 self.logger("Relative path is: " + str(repr(assets_path)), "INFO")
             placeholder_text = path.join(assets_path, f"{file_name}.png")
-            if not path.exists(assets_path):
-                makedirs(assets_path)
-            img.save(placeholder_text, "PNG")
+            img.save(abs_img_path, "PNG")
         else:
             base64_data = encode(img_bytes.getvalue(), "base64")
             base64_text = decode(base64_data, "ascii")

--- a/python3/pastify/validate.py
+++ b/python3/pastify/validate.py
@@ -18,7 +18,7 @@ def validate_config(config: Config, logger, filetype: str) -> bool:
             "You need to get a free API key for online saving, get one at https://api.imgbb.com/", "WARN")
         return False
 
-    if opts["save"] != "local" and opts["save"] != 'online':
+    if opts["save"] != "local" and opts["save"] != 'online' and opts["save"] != 'local_file':
         logger(
             str(opts['save']), "WARN")
         return False


### PR DESCRIPTION
Addresses the following issues:
* The `validate` function did not allow a value of `local_file` for the `save` config option.
* The `ImageGrab.save()` and `makedirs()` functions seemed not to work when using relative paths.