### PR TITLE
Add `$NAME$` to Custom Snippets for Filename Replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ require('pastify').setup {
 
 #### File Types
 
-Each filetype can have a custom snippet that will replace `$IMG$` with the image url. This can be useful for markdown, html, or latex.
+Each filetype can have a custom snippet that will replace the variables below. This can be useful for markdown, html, or latex.
+* `$IMG$`: The image url
+* `$NAME$`: The image filename
 
 ### Custom Keybinding
 
@@ -134,13 +136,13 @@ return {
                 default_ft = 'markdown', -- Default filetype to use
             },
             ft = { -- Custom snippets for different filetypes, will replace $IMG$ with the image url
-                html = '<img src="$IMG$" alt="">',
-                markdown = '![]($IMG$)',
+                html = '<img src="$IMG$" alt="$NAME$">',
+                markdown = '![$NAME$]($IMG$)',
                 tex = [[\includegraphics[width=\linewidth]{$IMG$}]],
                 css = 'background-image: url("$IMG$");',
                 js = 'const img = new Image(); img.src = "$IMG$";',
                 xml = '<image src="$IMG$" />',
-                php = '<?php echo "<img src=\"$IMG$\" alt=\"\">"; ?>',
+                php = '<?php echo "<img src=\"$IMG$\" alt=\"$NAME$\">"; ?>',
                 python = '# $IMG$',
                 java = '// $IMG$',
                 c = '// $IMG$',

--- a/lua/pastify.lua
+++ b/lua/pastify.lua
@@ -23,13 +23,13 @@ M.config = {
     default_ft = 'markdown',
   },
   ft = {
-    html = '<img src="$IMG$" alt="">',
-    markdown = '![]($IMG$)',
+    html = '<img src="$IMG$" alt="$NAME$">',
+    markdown = '![$NAME$]($IMG$)',
     tex = [[\includegraphics[width=\linewidth]{$IMG$}]],
     css = 'background-image: url("$IMG$");',
     js = 'const img = new Image(); img.src = "$IMG$";',
     xml = '<image src="$IMG$" />',
-    php = '<?php echo "<img src=\"$IMG$\" alt=\"\">"; ?>',
+    php = '<?php echo "<img src="$IMG$" alt="$NAME$">"; ?>',
     python = '# $IMG$',
     java = '// $IMG$',
     c = '// $IMG$',
@@ -58,10 +58,10 @@ M.getConfig = function()
 end
 
 M.getFileName = function()
-    if type(fileNameRule) == 'function' then
-        return fileNameRule()
-    end
-    return fileNameRule
+  if type(fileNameRule) == 'function' then
+    return fileNameRule()
+  end
+  return fileNameRule
 end
 
 M.createImagePathName = function()

--- a/python3/pastify/main.py
+++ b/python3/pastify/main.py
@@ -119,7 +119,11 @@ class Pastify(object):
 
         if filetype not in self.config["ft"]:
             filetype = self.config["opts"]["default_ft"]
-        pattern = self.config["ft"][filetype].replace("$IMG$", placeholder_text)
+        pattern = (
+            self.config["ft"][filetype]
+            .replace("$IMG$", placeholder_text)
+            .replace("$NAME$", file_name)
+        )
         # check if we're in visual mode to run a different command
         if vim.eval("mode()") in ["v", "V", ""]:
             vim.command(f"normal! c{pattern}")


### PR DESCRIPTION
This merge request introduces the `$NAME$` placeholder to custom snippets, allowing it to be replaced with the file name. The following changes were made:

- Added the `$NAME$` placeholder to custom snippets, ensuring it is replaced by the corresponding file name in various file types.
- Updated the code to handle the new `$NAME$` placeholder and perform the appropriate substitution.
- Revised the documentation to reflect the inclusion of `$NAME$` and its usage in the configuration.

Additionally, the `config` has been updated to utilize the `$NAME$` placeholder for file-related substitutions.

